### PR TITLE
Add Laravel 10 to CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        laravel: [9]
+        laravel: [9, 10]
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "nunomaduro/larastan": "^1.0|^2.0",
     "pestphp/pest": "^1.22",
     "pestphp/pest-plugin-laravel": "^1.3",
-    "laravel/pint": "^1.0"
+    "laravel/pint": "^1.6"
   },
   "extra": {
     "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "nunomaduro/larastan": "^1.0|^2.0",
     "pestphp/pest": "^1.22",
     "pestphp/pest-plugin-laravel": "^1.3",
-    "laravel/pint": "^1.6"
+    "laravel/pint": "^1.0"
   },
   "extra": {
     "laravel": {


### PR DESCRIPTION
Add Laravel 10 to CI Workflow to ensure tests pass correctly dependant on Laravel version.