### PR TITLE
docs: fix code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,12 @@ import { defineConfig } from "vite"
 import { watch } from "vite-plugin-watch"
 
 export default defineConfig({
-    watch({
-      pattern: "routes/*.php",
-      command: "php artisan trail:generate",
-    }),
+    plugins: [
+      watch({
+        pattern: "routes/*.php",
+        command: "php artisan trail:generate",
+      }),
+    ],
   ],
 })
 ```


### PR DESCRIPTION
This PR:

- [x] Fixes the code snippet for setting up `vite-plugin-watch` by putting the `watch` call inside the `plugins` array.