### PR TITLE
Fix typo in vite plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ import { defineConfig } from "vite"
 import { watch } from "vite-plugin-watch"
 
 export default defineConfig({
+  plugins: [
     watch({
       pattern: "routes/*.php",
       command: "php artisan trail:generate",


### PR DESCRIPTION
Small syntax fix. If someone is new to the Vite they might not understand where things need to go.

Cool package! I like it a lot more than just using Ziggy!