### PR TITLE
fix: Prevent view caching for blade directive

### DIFF
--- a/src/TrailServiceProvider.php
+++ b/src/TrailServiceProvider.php
@@ -34,6 +34,6 @@ class TrailServiceProvider extends ServiceProvider
 
     protected function registerDirective(): void
     {
-        Blade::directive('trail', fn () => TrailBladeGenerator::generate());
+        Blade::directive('trail', fn () => "<?php echo app('" . TrailBladeGenerator::class . "')::generate(); ?>");
     }
 }

--- a/tests/Pest/BladeDirectiveTest.php
+++ b/tests/Pest/BladeDirectiveTest.php
@@ -7,4 +7,4 @@ test('blade directive can be rendered', function () {
     $html = Blade::compileString('@trail');
 
     assertStringContainsString('window.trail', $html);
-});
+})->only();

--- a/tests/Pest/BladeDirectiveTest.php
+++ b/tests/Pest/BladeDirectiveTest.php
@@ -1,10 +1,18 @@
 <?php
 
 use Illuminate\Support\Facades\Blade;
+use Momentum\Trail\TrailBladeGenerator;
+use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertStringContainsString;
 
 test('blade directive can be rendered', function () {
     $html = Blade::compileString('@trail');
+
+    assertEquals("<?php echo app('" . TrailBladeGenerator::class . "')::generate(); ?>", $html);
+})->only();
+
+test('blade generator returns trail function', function () {
+    $html = TrailBladeGenerator::generate();
 
     assertStringContainsString('window.trail', $html);
 })->only();

--- a/tests/Pest/TrailTest.php
+++ b/tests/Pest/TrailTest.php
@@ -7,6 +7,7 @@ use Momentum\Trail\Trail;
 use function Pest\Laravel\artisan;
 use function PHPUnit\Framework\assertArrayHasKey;
 use function PHPUnit\Framework\assertFileExists;
+use Tightenco\Ziggy\Ziggy;
 
 beforeEach(function () {
     Route::prefix('profile')->name('profile.')->group(function () {
@@ -15,6 +16,9 @@ beforeEach(function () {
         Route::get('security', fn () => false)->name('security.show');
         Route::put('security', fn () => false)->name('security.update');
     });
+
+    // Other test cases may have called ziggy before, so we need to clear the route cache
+    Ziggy::clearRoutes();
 });
 
 test('trail generates a list of defined routes', function () {


### PR DESCRIPTION
This reintroduces similar behavior as Ziggy implements.
When generating the Blade output the code was automatically cached by
Laravels view system and thus always needed an `php artisan view:clear` when
introducing new routes and using the blade directive.

This now acts the same as Ziggy does. Please note, that Ziggy once
did also cache the view but returned to this approach, as it breaks
in certain scenarios and has no impactful performance impact:
See https://github.com/tighten/ziggy/pull/349
