### PR TITLE
Laravel 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - laravel: 9
-            php: "8.0"
+            php: "8.1"
           - laravel: 10
             php: "8.2"
           - laravel: 11
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include:
           - laravel: 9
-            php: "8.0"
+            php: "8.1"
           - laravel: 10
             php: "8.2"
           - laravel: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
             php: "8.2"
           - laravel: 11
             php: "8.3"
+          - laravel: 12
+            php: "8.3"
 
     steps:
       - name: Checkout code
@@ -52,6 +54,8 @@ jobs:
           - laravel: 10
             php: "8.2"
           - laravel: 11
+            php: "8.3"
+          - laravel: 12
             php: "8.3"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
   },
   "require": {
     "php": "^8.0",
-    "illuminate/support": "^8.24|^9.0|^10.0|^11.0",
+    "illuminate/support": "^8.24|^9.0|^10.0|^11.0|^12.0",
     "tightenco/ziggy": "^2.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^6.9|^7.0|^8.0|^9.0",
+    "orchestra/testbench": "^6.9|^7.0|^8.0|^9.0|10.0",
     "larastan/larastan": "^1.0|^2.0",
     "pestphp/pest": "^1.22|^2.0",
     "pestphp/pest-plugin-laravel": "^1.3|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "require-dev": {
     "orchestra/testbench": "^6.9|^7.0|^8.0|^9.0|10.0",
-    "larastan/larastan": "^1.0|^2.0",
+    "larastan/larastan": "^1.0|^2.0|^3.0",
     "pestphp/pest": "^1.22|^2.0|^3.0",
     "pestphp/pest-plugin-laravel": "^1.3|^2.0|^3.0",
     "laravel/pint": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     }
   },
   "require": {
-    "php": "^8.0",
-    "illuminate/support": "^8.24|^9.0|^10.0|^11.0|^12.0",
+    "php": "^8.1",
+    "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
     "tightenco/ziggy": "^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   "require-dev": {
     "orchestra/testbench": "^6.9|^7.0|^8.0|^9.0|10.0",
     "larastan/larastan": "^1.0|^2.0",
-    "pestphp/pest": "^1.22|^2.0",
-    "pestphp/pest-plugin-laravel": "^1.3|^2.0",
+    "pestphp/pest": "^1.22|^2.0|^3.0",
+    "pestphp/pest-plugin-laravel": "^1.3|^2.0|^3.0",
     "laravel/pint": "^1.0"
   },
   "extra": {

--- a/tests/Pest/BladeDirectiveTest.php
+++ b/tests/Pest/BladeDirectiveTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Blade;
+
 use function PHPUnit\Framework\assertStringContainsString;
 
 test('blade directive can be rendered', function () {

--- a/tests/Pest/TrailTest.php
+++ b/tests/Pest/TrailTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use Momentum\Trail\Trail;
+
 use function Pest\Laravel\artisan;
 use function PHPUnit\Framework\assertArrayHasKey;
 use function PHPUnit\Framework\assertFileExists;


### PR DESCRIPTION
Adds support for Laravel 12.

The minimum dependencies also need to be adapted to Laravel 9 and PHP 8.1 equal to [ziggy 2.0](https://github.com/tighten/ziggy/releases/tag/v2.0.0).